### PR TITLE
Highlight through filter splitters when holding a cursor ghost

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -72,8 +72,8 @@ local function highlight(event)
     local data = global.data[index] or {}
     global.data[index] = data
     local unit_number = selected.unit_number --[[@as number]]
-    local filter = not player.is_cursor_empty() and player.cursor_stack.valid_for_read and player.cursor_stack.name
-    if data.filter == filter and data.origin.valid and data.origin.unit_number == unit_number then
+    local filter = utils.get_cursor_item_prototype_name(player)
+    if data.filter == filter and data.origin and data.origin.valid and data.origin.unit_number == unit_number then
         data.cycle = data.cycle % 3 + 1
     else
         data.cycle = 1

--- a/scripts/utils.lua
+++ b/scripts/utils.lua
@@ -19,4 +19,17 @@ function utils.check_entity(data, unit_number, lane, path, sides)
     end
 end
 
+---@param player LuaPlayer
+function utils.get_cursor_item_prototype_name(player)
+    if player.is_cursor_empty() then
+        return
+    end
+    if player.cursor_stack.valid_for_read and player.cursor_stack.name then
+        return player.cursor_stack.name
+    end
+    if player.cursor_ghost and player.cursor_ghost.valid then
+        return player.cursor_ghost.name
+    end
+end
+
 return utils


### PR DESCRIPTION
![bv-cursor-ghost](https://github.com/CodeGreen0386/belt-visualizer/assets/114549/3383f438-67e1-4c86-a5cd-c846995bfc41)

This functionality is especially important when using the Cursor Enhancements mod because it allows you to pipette items that you don't have in your inventory.